### PR TITLE
Get environment variables values only if `Config._allow_environment_variables` is True

### DIFF
--- a/derpconf/config.py
+++ b/derpconf/config.py
@@ -171,10 +171,7 @@ class Config(object):
             super(Config, self).__setattr__(name, value)
 
     def __getattribute__(self, name):
-        if name in ['allow_environment_variables']:
-            return super(Config, self).__getattribute__(name)
-
-        if self.allow_environment_variables:
+        if Config._allow_environment_variables:
             value = os.environ.get(name, None)
             if value is not None:
                 return value

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -49,6 +49,20 @@ class Configuration(Vows.Context):
             def should_not_have_lower_case_value(self, topic):
                 expect(hasattr(topic, 'baz')).to_be_false()
 
+        class WhenFileExistsAndEnvironmentVariablesAreNotAllowed(Vows.Context):
+            def teardown(self):
+                del os.environ["PROPER"]
+
+            def topic(self):
+                os.environ["PROPER"] = 'env var value'
+                Config._allow_environment_variables = False
+                return Config.load(fix('sample.conf'), defaults={
+                    'PROPER': 'PROPERVALUE'
+                })
+
+            def should_have_set_value_rather_than_env_var_value(self, topic):
+                expect(topic.PROPER).to_equal('PROPERVALUE')
+
         class WhenPathIsNone(Vows.Context):
             class AndConfNameExists(Vows.Context):
                 def topic(self):


### PR DESCRIPTION
The issue was that `self.allow_environment_variables` is the class method, and it's always gonna be a true value because the method exists. Thus, it would get the env var value even if it was not requested.

This may break some code because people they didn't realize they need a call to `Config.allow_environment_variables()` to make env vars work.

If this is not the expected behavior, please let me know.