### PR TITLE
Depend on pyVows, not tornado-pyvows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gevent
-tornado-pyvows
+pyVows
 coverage
 colorama
 tox

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from derpconf.version import __version__
 
 tests_require = [
     'gevent',
-    'tornado-pyvows',
+    'pyVows',
     'coverage',
     'colorama',
     'tox',

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py26, py27, py32, py33, pypy
 commands = make test
 deps =
     gevent
-    tornado-pyvows
+    pyVows
     coverage
     colorama
     six


### PR DESCRIPTION
I don't see any Tornado references in the codebase, so I doubt we need
a Tornado-specific wrapper around pyVows.
