### PR TITLE
Fix getting environment variables correctly when enabled.

### DIFF
--- a/derpconf/config.py
+++ b/derpconf/config.py
@@ -172,10 +172,10 @@ class Config(object):
             super(Config, self).__setattr__(name, value)
 
     def __getattribute__(self, name):
-        if name in ['allow_environment_variables']:
+        if name in ['_allow_environment_variables']:
             return super(Config, self).__getattribute__(name)
 
-        if self.allow_environment_variables:
+        if self._allow_environment_variables:
             value = os.environ.get(name, None)
             if value is not None:
                 return value

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -163,6 +163,21 @@ class Configuration(Vows.Context):
         def should_have_description(self, topic):
             expect(topic.get_description('some_key')).to_equal('test key')
 
+
+    class WhenEnvironmentVariablesIsDisabled(Vows.Context):
+        def topic(self):
+            Config._allow_environment_variables = False
+            config = Config.load(fix('sample.conf'))
+
+            try:
+                os.environ['FOO'] = "baz"
+                return config.FOO
+            finally:
+                del os.environ['FOO']
+
+        def should_be_equal_to_env(self, topic):
+            expect(topic).to_equal("bar")
+
     class WhenGettingFromEnvironment(Vows.Context):
         class WhenKeyDoesNotExistInConfiguration(Vows.Context):
             def topic(self):
@@ -175,6 +190,7 @@ class Configuration(Vows.Context):
 
             def should_be_equal_to_env(self, topic):
                 expect(topic).to_equal("test value")
+
 
         class WhenKeyExistsInConfigurationFile(Vows.Context):
             def topic(self):


### PR DESCRIPTION
I fixed a typo on _allow_environment_variables avoiding get the variables from environment.