### PR TITLE
Limit directory scanning to .conf files

### DIFF
--- a/derpconf/config.py
+++ b/derpconf/config.py
@@ -81,8 +81,9 @@ class Config(object):
             files = sorted(os.listdir(path))
 
             for file in files:
-                filepath = path + os.sep + file
-                conf = Config.__load_from_path(conf, filepath)
+                if file.endswith('.conf'):
+                    filepath = path + os.sep + file
+                    conf = Config.__load_from_path(conf, filepath)
 
             return conf
 

--- a/vows/fixtures/conf.d/03-sample.conf.bak
+++ b/vows/fixtures/conf.d/03-sample.conf.bak
@@ -1,0 +1,2 @@
+FOO="shouldn't"
+NEW="be a thing"


### PR DESCRIPTION
Looking at all files means potentially picking up
things that aren’t config files.

For example on Debian dpkg will make copies of files
during upgrades when defaults files in /etc have been
modified.