### PR TITLE
Use secure URI in Vcs-Git control header.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: debhelper (>= 9),
                python-six
 X-Python-Version: >= 2.6
 Homepage: https://github.com/globocom/derpconf
-Vcs-Git: git://github.com/globocom/derpconf.git
+Vcs-Git: https://github.com/globocom/derpconf.git
 Vcs-Browser: https://github.com/globocom/derpconf
 
 Package: python-derpconf


### PR DESCRIPTION
Use secure URI in Vcs-Git control header.

Fixes lintian: vcs-field-uses-insecure-uri
https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html
