### PR TITLE
Travis-ci: added support for ppc64le build along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
     - 2.7
     - 3.6
     - 3.8
 
+before_install:
+  - sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels
 install:
   - sudo apt-get install -y librtmp-dev libevent-dev
   - make setup


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/derpconf/builds/186180935 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!